### PR TITLE
Fixed RTIMU5883L undefined reference error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ Makefile*
 !Linux/RTIMULibDrive11/Makefile
 !Linux/RTIMULibCal/Makefile
 !Linux/RTIMULibvrpn/Makefile
-build/
+build*/
 debug/
 Debug/
 Release/

--- a/RTIMULib/RTIMULib.pri
+++ b/RTIMULib/RTIMULib.pri
@@ -57,6 +57,7 @@ HEADERS += $$PWD/RTIMULib.h \
     $$PWD/IMUDrivers/RTHumidityDefs.h \
     $$PWD/IMUDrivers/RTHumidityHTS221.h \
     $$PWD/IMUDrivers/RTHumidityHTU21D.h \
+	$$PWD/IMUDrivers/RTIMUHMC5883LADXL345.h \
 
 SOURCES += $$PWD/RTMath.cpp \
     $$PWD/RTIMUHal.cpp \
@@ -85,6 +86,4 @@ SOURCES += $$PWD/RTMath.cpp \
     $$PWD/IMUDrivers/RTHumidity.cpp \
     $$PWD/IMUDrivers/RTHumidityHTS221.cpp \
     $$PWD/IMUDrivers/RTHumidityHTU21D.cpp \
-
-
-
+	$$PWD/IMUDrivers/RTIMUHMC5883LADXL345.cpp \


### PR DESCRIPTION
Building RTIMULibDemoGL (and others) returned an `RTIMU5883L::RTIMU5883L(RTIMUSettings*)` undefined reference error. I fixed it by adding `RTIMUHMC5883LADXL345.h` and `RTIMUHMC5883LADXL345.cpp` to RTIMULib.pri.
I also modified .gitignore to ignore all `build*` directories (instead of only `build`).